### PR TITLE
feat: KAN-728 permissions refresh in lambda projects

### DIFF
--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -1,5 +1,4 @@
-
-name: Check new policy 
+name: Check new policy
 
 on:
   workflow_call:
@@ -37,6 +36,7 @@ jobs:
     defaults:
       run:
         working-directory: ${{ inputs.working_dir }}/tf
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -55,30 +55,46 @@ jobs:
 
       - name: Check for modified policy JSON files
         id: check-modified-files
+        shell: bash
         env:
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          # Get modified policy JSON files in the 'tf' directory and exclude child directory 
-          modified_files=$(git diff --name-only HEAD~1 HEAD | grep "^$WORKING_DIR/tf/[^/]*\.json$" || true)
-          modified_default_files=$(git diff --name-only HEAD~1 HEAD | grep "^$WORKING_DIR/tf/default-policy/.*\.json$" || true)
-
-          if [ -n "$modified_default_files" ]; then
-            echo "[INFO] Modified default policy files found: $modified_default_files"
-            echo "default-modified=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "[INFO] No modified default policy files found"
-            echo "default-modified=false" >> "$GITHUB_OUTPUT"
-          fi
-
+          # 1) Detect changed policy JSON files
+          modified_files=$(git diff --name-only HEAD~1 HEAD \
+            | grep "^$WORKING_DIR/tf/[^/]*\.json$" || true)
           if [ -n "$modified_files" ]; then
-            echo "[INFO] Modified policy files found: $modified_files"
+            echo "[INFO] Modified policy JSON files: $modified_files"
             echo "modified=true" >> "$GITHUB_OUTPUT"
           else
-            echo "[INFO] No modified policy files found."
+            echo "[INFO] No modified policy JSON files found."
             echo "modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Update default policy 
+          # 2) Detect any Terraform (.tf) changes
+          tf_changed=$(git diff --name-only HEAD~1 HEAD \
+            | grep "^$WORKING_DIR/tf/.*\.tf$" || true)
+          if [ -n "$tf_changed" ]; then
+            echo "[INFO] Terraform files changed: $tf_changed"
+            echo "tf-modified=true" >> "$GITHUB_OUTPUT"
+            echo "tf-files=$(printf '%s ' $tf_changed)" >> "$GITHUB_OUTPUT"
+          else
+            echo "[INFO] No Terraform changes detected."
+            echo "tf-modified=false" >> "$GITHUB_OUTPUT"
+            echo "tf-files=" >> "$GITHUB_OUTPUT"
+          fi
+
+          # 3) Detect changed default-policy JSON files
+          modified_default_files=$(git diff --name-only HEAD~1 HEAD \
+            | grep "^$WORKING_DIR/tf/default-policy/.*\.json$" || true)
+          if [ -n "$modified_default_files" ]; then
+            echo "[INFO] Modified default-policy JSON files: $modified_default_files"
+            echo "default-modified=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "[INFO] No modified default-policy JSON files found."
+            echo "default-modified=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update default policy
         if: steps.check-modified-files.outputs.default-modified == 'true'
         working-directory: ${{ inputs.working_dir }}/tf/default-policy/
         env:
@@ -89,50 +105,50 @@ jobs:
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-
-          # Get modified policy JSON files in the 'tf/default-policy' 
-          modified_default_files=$(git diff --name-only HEAD~1 HEAD | grep "^$WORKING_DIR/tf/default-policy/.*\.json$")
+          # Get modified default-policy JSON files
+          modified_default_files=$(git diff --name-only HEAD~1 HEAD \
+            | grep "^$WORKING_DIR/tf/default-policy/.*\.json$")
 
           for file in $modified_default_files; do
-            # Skip the file if it's named Trust.json
-            if [[ $(basename "$file") == "TrustPolicy.json" || $(basename "$file") == "ECRCrossAccountAccessPolicy.json" ]]; then
+            # Skip TrustPolicy.json and ECRCrossAccountAccessPolicy.json
+            base=$(basename "$file")
+            if [[ "$base" == "TrustPolicy.json" || "$base" == "ECRCrossAccountAccessPolicy.json" ]]; then
               continue
             fi
 
-            file_path=$(basename $file)
-            policy_name="$PROJECT_NAME-$(basename $file_path .json)" 
+            policy_name="$PROJECT_NAME-${base%.json}"
+            echo "[INFO] Updating default policy $policy_name from $base"
 
-            echo "[INFO] Replace values in policy file $file_name"
+            # Substitute placeholders
             sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
-            s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
-            s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
-            s/\${ORG_AWS_ACCOUNT_ID}/$ORG_AWS_ACCOUNT_ID/g; \
-            s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
-            s/\${PROJECT_NAME}/$PROJECT_NAME/g" $file_path
+                    s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
+                    s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
+                    s/\${ORG_AWS_ACCOUNT_ID}/$ORG_AWS_ACCOUNT_ID/g; \
+                    s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
+                    s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$base"
 
-            # Get all versions of the policy
-            policy_versions=$(aws iam list-policy-versions \
+            # Delete non-default policy versions
+            versions=$(aws iam list-policy-versions \
               --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
               --query 'Versions[?IsDefaultVersion==`false`].VersionId' \
               --output text)
-
-            # Loop through old versions and delete them
-            for version_id in $policy_versions; do
-              echo "[INFO] Deleting old version: $version_id"
+            for v in $versions; do
+              echo "[INFO] Deleting old version $v"
               aws iam delete-policy-version \
                 --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
-                --version-id "$version_id"
+                --version-id "$v"
             done
 
-            echo "[INFO] Update $policy_name with new version"
+            # Create new default version
+            echo "[INFO] Creating new default version of $policy_name"
             aws iam create-policy-version \
-            --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
-            --policy-document file://$file_path \
-            --set-as-default
+              --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
+              --policy-document file://"$base" \
+              --set-as-default
           done
 
       - name: Create and attach temporary policy
-        if: steps.check-modified-files.outputs.modified == 'true'
+        if: steps.check-modified-files.outputs.modified == 'true' || steps.check-modified-files.outputs.tf-modified == 'true'
         working-directory: ${{ inputs.working_dir }}/tf/
         env:
           PROJECT_NAME: ${{ inputs.project_name }}
@@ -142,71 +158,56 @@ jobs:
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          # Get the current date in the format YYYYMMDDHHMMSS with GMT-6 offset
+          # Generate a unique name for this temporary policy
           timestamp=$(date -u +"%Y%m%d%H%M%S" -d '-6 hours')
-          uuid=$(uuidgen | cut -c1-8)   # Get first 8 chars of UUID
-
-          # GitHubActionsRole
-          github_action_role="$PROJECT_NAME-GitHubActionsRole"
-
-          # Get modified policy JSON files in the 'tf' directory and exclude child directory 
-          modified_files=$(git diff --name-only HEAD~1 HEAD | grep "^$WORKING_DIR/tf/[^/]*\.json$")
-          policy_file="temporary-${timestamp}-${uuid}.json"
+          uuid=$(uuidgen | cut -c1-8)
           policy_name="temporary-${timestamp}-${uuid}"
+          policy_file="${policy_name}.json"
 
-          # Initialize the combined policy structure
-          echo '{
-              "Version": "2012-10-17",
-              "Statement": [' > $policy_file
+          # Decide which JSON files to include
+          if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
+            # Use only the JSON files that actually changed
+            files=($(git diff --name-only HEAD~1 HEAD \
+              | grep "^$WORKING_DIR/tf/[^/]*\.json$"))
+          else
+            # Scan changed TF files for templatefile("...json") references
+            echo "[INFO] Scanning changed TF for JSON references"
+            read -r -a tf_list <<< "${{ steps.check-modified-files.outputs.tf-files }}"
+            refs=()
+            for tf in "${tf_list[@]}"; do
+              grep -hoE 'templatefile\("([^"]+\.json)"' \
+                "$WORKING_DIR/tf/$tf" \
+                | sed -E 's/templatefile\("([^"]+)"\)/\1/' \
+                | while read -r f; do refs+=("$f"); done
+            done
+            files=($(printf "%s\n" "${refs[@]}" | sort -u))
+          fi
 
-          first_statement=true
-
-          # Process each file
-          for file in $modified_files; do
-            echo "[INFO] file: $file"
-            # Check if file exists
-            file_name=$(basename "$file")
-            if [ ! -f "$file_name" ]; then
-              echo "Error: File $file_name not found"
-              continue
+          # Build the combined temporary policy document
+          echo '{ "Version": "2012-10-17", "Statement": [' > "$policy_file"
+          first=true
+          for file in "${files[@]}"; do
+            if [ "$first" = true ]; then
+              first=false
+            else
+              echo "," >> "$policy_file"
             fi
-
-            # Extract the Statement array from each policy file and append
-            statements=$(jq -c '.Statement[]' "$file_name")
-            while IFS= read -r statement; do
-              # Add a comma if it's not the first statement
-              if [ "$first_statement" = true ]; then
-                first_statement=false
-              else
-                echo "," >> $policy_file
-              fi
-              echo "$statement" >> $policy_file
-            done <<<"$statements"
+            jq -c '.Statement[]' "$file" >> "$policy_file"
           done
+          echo ']}' >> "$policy_file"
 
-          # Close the JSON structure
-          echo '
-              ]
-          }' >> $policy_file
-
-          # Format the final JSON file nicely
-          jq '.' $policy_file > temp.json && mv temp.json $policy_file
-
-
+          # Substitute placeholders
           sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
-          s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
-          s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
-          s/\${ORG_AWS_ACCOUNT_ID}/$ORG_AWS_ACCOUNT_ID/g; \
-          s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
-          s/\${PROJECT_NAME}/$PROJECT_NAME/g" $policy_file
-          
-          echo "[INFO] Create policy $policy_name"
+                  s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
+                  s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
+                  s/\${ORG_AWS_ACCOUNT_ID}/$ORG_AWS_ACCOUNT_ID/g; \
+                  s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
+                  s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$policy_file"
+
+          # Create and attach the IAM policy
           aws iam create-policy \
-            --policy-name $policy_name \
-            --policy-document file://$policy_file
-          
-          # Attach policy to the GitHubActionsRole
-          echo "[INFO] Attach $policy_name to $github_action_role" 
+            --policy-name "$policy_name" \
+            --policy-document file://"$policy_file"
           aws iam attach-role-policy \
-            --role-name $github_action_role \
+            --role-name "${PROJECT_NAME}-GitHubActionsRole" \
             --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name"

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -52,49 +52,48 @@ jobs:
       - name: Debug AWS credentials configuration
         run: aws sts get-caller-identity
 
-      - name: Check for modified policy JSON & TF files
+      - name: Check for modified JSON & TF files
         id: check-modified-files
         shell: bash
         env:
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
           # 1) JSON diffs
-          modified_json_paths=$(git diff --name-only HEAD~1 HEAD \
+          modified_json=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/[^/]*\.json$" || true)
-          if [[ -n "$modified_json_paths" ]]; then
-            echo "[INFO] Modified policy JSON files: $modified_json_paths"
+          if [[ -n "$modified_json" ]]; then
+            echo "[INFO] JSON changed: $modified_json"
             echo "modified=true" >> "$GITHUB_OUTPUT"
           else
-            echo "[INFO] No modified policy JSON files found."
+            echo "[INFO] No policy-JSON changes"
             echo "modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # 2) TF diffs → capture only basenames
+          # 2) TF diffs → basenames only
           tf_paths=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/.*\.tf$" || true)
           if [[ -n "$tf_paths" ]]; then
-            echo "[INFO] Terraform files changed: $tf_paths"
+            echo "[INFO] TF changed: $tf_paths"
             echo "tf-modified=true" >> "$GITHUB_OUTPUT"
             tf_basenames=()
             for p in $tf_paths; do
               tf_basenames+=( "$(basename "$p")" )
             done
-            # join with spaces
-            echo "tf-files=$(printf '%s ' "${tf_basenames[@]}")" >> "$GITHUB_OUTPUT"
+            echo "tf-files=${tf_basenames[*]}" >> "$GITHUB_OUTPUT"
           else
-            echo "[INFO] No Terraform changes detected."
+            echo "[INFO] No Terraform changes"
             echo "tf-modified=false" >> "$GITHUB_OUTPUT"
             echo "tf-files=" >> "$GITHUB_OUTPUT"
           fi
 
           # 3) Default-policy JSON diffs
-          modified_default_paths=$(git diff --name-only HEAD~1 HEAD \
+          default_json=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/default-policy/.*\.json$" || true)
-          if [[ -n "$modified_default_paths" ]]; then
-            echo "[INFO] Modified default-policy JSON files: $modified_default_paths"
+          if [[ -n "$default_json" ]]; then
+            echo "[INFO] Default-policy JSON changed: $default_json"
             echo "default-modified=true" >> "$GITHUB_OUTPUT"
           else
-            echo "[INFO] No modified default-policy JSON files found."
+            echo "[INFO] No default-policy JSON changes"
             echo "default-modified=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -108,34 +107,30 @@ jobs:
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
           ORG_AWS_REGION: ${{ vars.AWS_REGION }}
         run: |
-          modified_default_files=$(git diff --name-only HEAD~1 HEAD \
+          defaults=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/default-policy/.*\.json$")
-          for file in $modified_default_files; do
+          for file in $defaults; do
             base=$(basename "$file")
-            if [[ "$base" == "TrustPolicy.json" || "$base" == "ECRCrossAccountAccessPolicy.json" ]]; then
-              continue
-            fi
-            policy_name="$PROJECT_NAME-${base%.json}"
-            echo "[INFO] Updating default policy $policy_name from $base"
-            sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
-                    s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
-                    s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
-                    s/\${ORG_AWS_ACCOUNT_ID}/$ORG_AWS_ACCOUNT_ID/g; \
-                    s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
-                    s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$base"
+            [[ "$base" =~ ^(TrustPolicy|ECRCrossAccountAccessPolicy)\.json$ ]] && continue
+            policy="$PROJECT_NAME-${base%.json}"
+            echo "[INFO] Updating $policy from $base"
+            sed -i "s|\${AWS_REGION}|$AWS_REGION|g; \
+                    s|\${AWS_ACCOUNT_ID}|$AWS_ACCOUNT_ID|g; \
+                    s|\${USER_NAME}|$GITHUB_REPOSITORY_OWNER|g; \
+                    s|\${ORG_AWS_ACCOUNT_ID}|$ORG_AWS_ACCOUNT_ID|g; \
+                    s|\${ORG_AWS_REGION}|$ORG_AWS_REGION|g; \
+                    s|\${PROJECT_NAME}|$PROJECT_NAME|g" "$base"
             versions=$(aws iam list-policy-versions \
-              --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
+              --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy" \
               --query 'Versions[?IsDefaultVersion==`false`].VersionId' \
               --output text)
             for v in $versions; do
-              echo "[INFO] Deleting old version $v"
               aws iam delete-policy-version \
-                --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
+                --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy" \
                 --version-id "$v"
             done
-            echo "[INFO] Creating new default version of $policy_name"
             aws iam create-policy-version \
-              --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
+              --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy" \
               --policy-document file://"$base" \
               --set-as-default
           done
@@ -149,63 +144,65 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
           ORG_AWS_REGION: ${{ vars.AWS_REGION }}
+          TF_FILES: ${{ steps.check-modified-files.outputs.tf-files }}
         run: |
-          # 1) Generate unique policy name
-          timestamp=$(date -u +"%Y%m%d%H%M%S" -d '-6 hours')
-          uuid=$(uuidgen | cut -c1-8)
-          policy_name="temporary-${timestamp}-${uuid}"
-          policy_file="${policy_name}.json"
+          echo "[DEBUG] pwd=$(pwd)"
+          echo "[DEBUG] ls=$(ls)"
+          echo "[DEBUG] TF_FILES='$TF_FILES'"
 
-          # 2) Determine which JSONs to bundle
+          # 1) build list of JSON basenames
           if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
-            echo "[INFO] Bundling only changed JSON policies"
-            mapfile -t json_paths < <(git diff --name-only HEAD~1 HEAD \
+            mapfile -t jsons < <(git diff --name-only HEAD~1 HEAD \
               | grep "^$WORKING_DIR/tf/[^/]*\.json$")
             files=()
-            for p in "${json_paths[@]}"; do
+            for p in "${jsons[@]}"; do
               files+=( "$(basename "$p")" )
             done
           else
-            echo "[INFO] Scanning changed TF for JSON references"
-            read -r -a tf_list <<< "${{ steps.check-modified-files.outputs.tf-files }}"
+            echo "[INFO] scanning TF → JSON references"
+            read -ra tf_list <<< "$TF_FILES"
             refs=()
             for tf in "${tf_list[@]}"; do
               grep -hoE 'templatefile\("([^"]+\.json)"\)' "$tf" \
                 | sed -E 's/templatefile\("([^"]+)"\)/\1/' \
                 | while read -r f; do refs+=("$f"); done
             done
-            files=($(printf "%s\n" "${refs[@]}" | sort -u))
+            files=( $(printf "%s\n" "${refs[@]}" | sort -u) )
           fi
 
-          echo "[INFO] Files to attach: ${files[*]}"
+          echo "[DEBUG] policy JSONs = ${files[*]}"
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "[INFO] no JSON to bundle → skipping CreatePolicy"
+            exit 0
+          fi
 
-          # 3) Build the temporary policy doc
+          # 2) assemble the temp policy
+          ts=$(date -u +"%Y%m%d%H%M%S" -d '-6 hours')
+          id=$(uuidgen | cut -c1-8)
+          pol="temporary-${ts}-${id}.json"
           {
-            echo '{ "Version": "2012-10-17", "Statement": ['
+            echo '{ "Version":"2012-10-17","Statement":['
             first=true
             for f in "${files[@]}"; do
-              if $first; then
-                first=false
-              else
-                echo ","
-              fi
+              $first && first=false || echo ","
               jq -c '.Statement[]' "$f"
             done
             echo "]}"
-          } > "$policy_file"
+          } > "$pol"
 
-          # 4) Substitute placeholders
-          sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
-                  s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
-                  s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
-                  s/\${ORG_AWS_ACCOUNT_ID}/$ORG_AWS_ACCOUNT_ID/g; \
-                  s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
-                  s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$policy_file"
+          # 3) substitute placeholders
+          sed -i "s|\${AWS_REGION}|$AWS_REGION|g; \
+                  s|\${AWS_ACCOUNT_ID}|$AWS_ACCOUNT_ID|g; \
+                  s|\${USER_NAME}|$GITHUB_REPOSITORY_OWNER|g; \
+                  s|\${ORG_AWS_ACCOUNT_ID}|$ORG_AWS_ACCOUNT_ID|g; \
+                  s|\${ORG_AWS_REGION}|$ORG_AWS_REGION|g; \
+                  s|\${PROJECT_NAME}|$PROJECT_NAME|g" "$pol"
 
-          # 5) Create & attach
+          # 4) publish
           aws iam create-policy \
-            --policy-name "$policy_name" \
-            --policy-document file://"$policy_file"
+            --policy-name "${pol%.json}" \
+            --policy-document file://"$pol"
           aws iam attach-role-policy \
             --role-name "${PROJECT_NAME}-GitHubActionsRole" \
-            --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name"
+            --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/${pol%.json}"
+

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -146,11 +146,6 @@ jobs:
           ORG_AWS_REGION: ${{ vars.AWS_REGION }}
           TF_FILES: ${{ steps.check-modified-files.outputs.tf-files }}
         run: |
-          # Debug prints
-          echo "[DEBUG] pwd=$(pwd)"
-          echo "[DEBUG] ls=$(ls -1)"
-          echo "[DEBUG] TF_FILES='$TF_FILES'"
-
           # 1) Determine JSON files to bundle
           if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
             mapfile -t json_paths < <(git diff --name-only HEAD~1 HEAD \
@@ -160,7 +155,6 @@ jobs:
             echo "[INFO] scanning TF → JSON references via sed"
             refs=()
             for tf in $TF_FILES; do 
-              echo "[DEBUG] tf='$tf'"
               # sed pulls out the .json filename from templatefile("xxx.json",...)
               while read -r f; do
                 refs+=("$f")
@@ -171,7 +165,7 @@ jobs:
             files=( $(printf "%s\n" "${refs[@]}" | sort -u) )
           fi
 
-          echo "[DEBUG] policy JSONs = ${files[*]}"
+          echo "Will be attached policy JSONs = ${files[*]}"
           if [ ${#files[@]} -eq 0 ]; then
             echo "[INFO] no JSON to bundle → skipping CreatePolicy"
             exit 0

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -165,13 +165,11 @@ jobs:
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          # 1) Generate unique temporary policy name
           timestamp=$(date -u +"%Y%m%d%H%M%S" -d '-6 hours')
           uuid=$(uuidgen | cut -c1-8)
           policy_name="temporary-${timestamp}-${uuid}"
           policy_file="${policy_name}.json"
 
-          # 2) Decide which JSON(s) to bundle
           if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
             echo "[INFO] Bundling only changed JSON policies"
             mapfile -t paths < <(git diff --name-only HEAD~1 HEAD \
@@ -180,14 +178,12 @@ jobs:
             for p in "${paths[@]}"; do
               files+=( "$(basename "$p")" )
             done
-
           else
             echo "[INFO] No JSON diff; scanning TF for JSON references"
             read -r -a tf_list <<< "${{ steps.check-modified-files.outputs.tf-files }}"
             refs=()
             for tf in "${tf_list[@]}"; do
-              grep -hoE 'templatefile\("([^"]+\.json)"\)' \
-                "$WORKING_DIR/tf/$tf" \
+              grep -hoE 'templatefile\("([^"]+\.json)"\)' "$tf" \
                 | sed -E 's/templatefile\("([^"]+)"\)/\1/' \
                 | while read -r f; do refs+=("$f"); done
             done
@@ -196,7 +192,6 @@ jobs:
 
           echo "[INFO] Files to attach: ${files[*]}"
 
-          # 3) Build combined temporary policy document
           echo '{ "Version":"2012-10-17", "Statement":[' > "$policy_file"
           first=true
           for f in "${files[@]}"; do
@@ -209,7 +204,6 @@ jobs:
           done
           echo "]}" >> "$policy_file"
 
-          # 4) Substitute placeholders
           sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
                   s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
                   s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
@@ -217,10 +211,9 @@ jobs:
                   s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
                   s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$policy_file"
 
-          # 5) Create and attach the IAM policy
           aws iam create-policy \
             --policy-name "$policy_name" \
             --policy-document file://"$policy_file"
           aws iam attach-role-policy \
             --role-name "${PROJECT_NAME}-GitHubActionsRole" \
-            --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name"
+            --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" 

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -167,7 +167,6 @@ jobs:
 
           if [ ${#files[@]} -eq 0 ]; then
             echo "[INFO] no JSON to bundle → skipping CreatePolicy"
-            exit 0
           fi
 
           # 2) Build the combined policy document

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -146,25 +146,23 @@ jobs:
           ORG_AWS_REGION: ${{ vars.AWS_REGION }}
           TF_FILES: ${{ steps.check-modified-files.outputs.tf-files }}
         run: |
+          # Debug prints
           echo "[DEBUG] pwd=$(pwd)"
-          echo "[DEBUG] ls=$(ls)"
+          echo "[DEBUG] ls=$(ls -1)"
           echo "[DEBUG] TF_FILES='$TF_FILES'"
 
-          # 1) build list of JSON basenames
+          # 1) Determine JSON files to bundle
           if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
-            mapfile -t jsons < <(git diff --name-only HEAD~1 HEAD \
+            mapfile -t json_paths < <(git diff --name-only HEAD~1 HEAD \
               | grep "^$WORKING_DIR/tf/[^/]*\.json$")
-            files=()
-            for p in "${jsons[@]}"; do
-              files+=( "$(basename "$p")" )
-            done
+            files=(); for p in "${json_paths[@]}"; do files+=( "$(basename "$p")" ); done
           else
             echo "[INFO] scanning TF → JSON references"
             read -ra tf_list <<< "$TF_FILES"
             refs=()
             for tf in "${tf_list[@]}"; do
-              grep -hoE 'templatefile\("([^"]+\.json)"\)' "$tf" \
-                | sed -E 's/templatefile\("([^"]+)"\)/\1/' \
+              # use -P lookbehind to grab only the filename
+              grep -hoP '(?<=templatefile\(")[^"]+\.json' "$tf" \
                 | while read -r f; do refs+=("$f"); done
             done
             files=( $(printf "%s\n" "${refs[@]}" | sort -u) )
@@ -176,7 +174,7 @@ jobs:
             exit 0
           fi
 
-          # 2) assemble the temp policy
+          # 2) Build the combined policy document
           ts=$(date -u +"%Y%m%d%H%M%S" -d '-6 hours')
           id=$(uuidgen | cut -c1-8)
           pol="temporary-${ts}-${id}.json"
@@ -190,7 +188,7 @@ jobs:
             echo "]}"
           } > "$pol"
 
-          # 3) substitute placeholders
+          # 3) Substitute placeholders
           sed -i "s|\${AWS_REGION}|$AWS_REGION|g; \
                   s|\${AWS_ACCOUNT_ID}|$AWS_ACCOUNT_ID|g; \
                   s|\${USER_NAME}|$GITHUB_REPOSITORY_OWNER|g; \
@@ -198,11 +196,10 @@ jobs:
                   s|\${ORG_AWS_REGION}|$ORG_AWS_REGION|g; \
                   s|\${PROJECT_NAME}|$PROJECT_NAME|g" "$pol"
 
-          # 4) publish
+          # 4) Publish
           aws iam create-policy \
             --policy-name "${pol%.json}" \
             --policy-document file://"$pol"
           aws iam attach-role-policy \
             --role-name "${PROJECT_NAME}-GitHubActionsRole" \
             --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/${pol%.json}"
-

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -159,7 +159,8 @@ jobs:
           else
             echo "[INFO] scanning TF → JSON references via sed"
             refs=()
-            for tf in "${tf_list[@]}"; do
+            for tf in $TF_FILES; do 
+              echo "[DEBUG] tf='$tf'"
               # sed pulls out the .json filename from templatefile("xxx.json",...)
               while read -r f; do
                 refs+=("$f")

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -165,7 +165,6 @@ jobs:
             files=( $(printf "%s\n" "${refs[@]}" | sort -u) )
           fi
 
-          echo "Will be attached policy JSONs = ${files[*]}"
           if [ ${#files[@]} -eq 0 ]; then
             echo "[INFO] no JSON to bundle → skipping CreatePolicy"
             exit 0

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -157,13 +157,15 @@ jobs:
               | grep "^$WORKING_DIR/tf/[^/]*\.json$")
             files=(); for p in "${json_paths[@]}"; do files+=( "$(basename "$p")" ); done
           else
-            echo "[INFO] scanning TF → JSON references"
-            read -ra tf_list <<< "$TF_FILES"
+            echo "[INFO] scanning TF → JSON references via sed"
             refs=()
             for tf in "${tf_list[@]}"; do
-              # use -P lookbehind to grab only the filename
-              grep -hoP '(?<=templatefile\(")[^"]+\.json' "$tf" \
-                | while read -r f; do refs+=("$f"); done
+              # sed pulls out the .json filename from templatefile("xxx.json",...)
+              while read -r f; do
+                refs+=("$f")
+              done < <(
+                sed -nE 's/.*templatefile\("([^"]+\.json)"\,.*/\1/p' "$tf"
+              )
             done
             files=( $(printf "%s\n" "${refs[@]}" | sort -u) )
           fi

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -139,6 +139,7 @@ jobs:
         if: steps.check-modified-files.outputs.modified == 'true' || steps.check-modified-files.outputs.tf-modified == 'true'
         working-directory: ${{ inputs.working_dir }}/tf/
         env:
+          WORKING_DIR: ${{ inputs.working_dir }}
           PROJECT_NAME: ${{ inputs.project_name }}
           AWS_ACCOUNT_ID: ${{ inputs.aws_account_id }}
           AWS_REGION: ${{ vars.AWS_REGION }}
@@ -148,6 +149,7 @@ jobs:
         run: |
           # 1) Determine JSON files to bundle
           if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
+            echo "[INFO] group the JSON policy files to attach"
             mapfile -t json_paths < <(git diff --name-only HEAD~1 HEAD \
               | grep "^$WORKING_DIR/tf/[^/]*\.json$")
             files=(); for p in "${json_paths[@]}"; do files+=( "$(basename "$p")" ); done
@@ -167,6 +169,7 @@ jobs:
 
           if [ ${#files[@]} -eq 0 ]; then
             echo "[INFO] no JSON to bundle → skipping CreatePolicy"
+            exit 0
           fi
 
           # 2) Build the combined policy document

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -60,30 +60,23 @@ jobs:
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
           # 1) Detect changed policy JSON files
-          modified_json_paths=$(git diff --name-only HEAD~1 HEAD \
+          modified_files=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/[^/]*\.json$" || true)
-          if [[ -n "$modified_json_paths" ]]; then
-            echo "[INFO] Modified policy JSON files: $modified_json_paths"
+          if [ -n "$modified_files" ]; then
+            echo "[INFO] Modified policy JSON files: $modified_files"
             echo "modified=true" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No modified policy JSON files found."
             echo "modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # 2) Detect any Terraform (.tf) changes, emit only basenames
-          tf_paths=$(git diff --name-only HEAD~1 HEAD \
+          # 2) Detect any Terraform (.tf) changes
+          tf_changed=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/.*\.tf$" || true)
-          if [[ -n "$tf_paths" ]]; then
-            echo "[INFO] Terraform files changed: $tf_paths"
+          if [ -n "$tf_changed" ]; then
+            echo "[INFO] Terraform files changed: $tf_changed"
             echo "tf-modified=true" >> "$GITHUB_OUTPUT"
-
-            # strip prefix, keep only basename
-            basenames=()
-            for path in $tf_paths; do
-              basenames+=( "$(basename "$path")" )
-            done
-            tf_files=$(printf "%s " "${basenames[@]}")
-            echo "tf-files=$tf_files" >> "$GITHUB_OUTPUT"
+            echo "tf-files=$(printf '%s ' $tf_changed)" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No Terraform changes detected."
             echo "tf-modified=false" >> "$GITHUB_OUTPUT"
@@ -91,10 +84,10 @@ jobs:
           fi
 
           # 3) Detect changed default-policy JSON files
-          modified_default_paths=$(git diff --name-only HEAD~1 HEAD \
+          modified_default_files=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/default-policy/.*\.json$" || true)
-          if [[ -n "$modified_default_paths" ]]; then
-            echo "[INFO] Modified default-policy JSON files: $modified_default_paths"
+          if [ -n "$modified_default_files" ]; then
+            echo "[INFO] Modified default-policy JSON files: $modified_default_files"
             echo "default-modified=true" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No modified default-policy JSON files found."
@@ -117,8 +110,8 @@ jobs:
             | grep "^$WORKING_DIR/tf/default-policy/.*\.json$")
 
           for file in $modified_default_files; do
-            base=$(basename "$file")
             # Skip TrustPolicy.json and ECRCrossAccountAccessPolicy.json
+            base=$(basename "$file")
             if [[ "$base" == "TrustPolicy.json" || "$base" == "ECRCrossAccountAccessPolicy.json" ]]; then
               continue
             fi
@@ -134,7 +127,7 @@ jobs:
                     s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
                     s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$base"
 
-            # Delete any old non-default versions
+            # Delete non-default policy versions
             versions=$(aws iam list-policy-versions \
               --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
               --query 'Versions[?IsDefaultVersion==`false`].VersionId' \
@@ -165,45 +158,45 @@ jobs:
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
+          # Generate a unique name for this temporary policy
           timestamp=$(date -u +"%Y%m%d%H%M%S" -d '-6 hours')
           uuid=$(uuidgen | cut -c1-8)
           policy_name="temporary-${timestamp}-${uuid}"
           policy_file="${policy_name}.json"
 
+          # Decide which JSON files to include
           if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
-            echo "[INFO] Bundling only changed JSON policies"
-            mapfile -t paths < <(git diff --name-only HEAD~1 HEAD \
-              | grep "^$WORKING_DIR/tf/[^/]*\.json$")
-            files=()
-            for p in "${paths[@]}"; do
-              files+=( "$(basename "$p")" )
-            done
+            # Use only the JSON files that actually changed
+            files=($(git diff --name-only HEAD~1 HEAD \
+              | grep "^$WORKING_DIR/tf/[^/]*\.json$"))
           else
-            echo "[INFO] No JSON diff; scanning TF for JSON references"
+            # Scan changed TF files for templatefile("...json") references
+            echo "[INFO] Scanning changed TF for JSON references"
             read -r -a tf_list <<< "${{ steps.check-modified-files.outputs.tf-files }}"
             refs=()
             for tf in "${tf_list[@]}"; do
-              grep -hoE 'templatefile\("([^"]+\.json)"\)' "$tf" \
+              grep -hoE 'templatefile\("([^"]+\.json)"' \
+                "$WORKING_DIR/tf/$tf" \
                 | sed -E 's/templatefile\("([^"]+)"\)/\1/' \
                 | while read -r f; do refs+=("$f"); done
             done
             files=($(printf "%s\n" "${refs[@]}" | sort -u))
           fi
 
-          echo "[INFO] Files to attach: ${files[*]}"
-
-          echo '{ "Version":"2012-10-17", "Statement":[' > "$policy_file"
+          # Build the combined temporary policy document
+          echo '{ "Version": "2012-10-17", "Statement": [' > "$policy_file"
           first=true
-          for f in "${files[@]}"; do
-            if [[ "$first" == true ]]; then
+          for file in "${files[@]}"; do
+            if [ "$first" = true ]; then
               first=false
             else
               echo "," >> "$policy_file"
             fi
-            jq -c '.Statement[]' "$f" >> "$policy_file"
+            jq -c '.Statement[]' "$file" >> "$policy_file"
           done
-          echo "]}" >> "$policy_file"
+          echo ']}' >> "$policy_file"
 
+          # Substitute placeholders
           sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
                   s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
                   s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
@@ -211,9 +204,10 @@ jobs:
                   s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
                   s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$policy_file"
 
+          # Create and attach the IAM policy
           aws iam create-policy \
             --policy-name "$policy_name" \
             --policy-document file://"$policy_file"
           aws iam attach-role-policy \
             --role-name "${PROJECT_NAME}-GitHubActionsRole" \
-            --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" 
+            --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name"

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -20,7 +20,7 @@ on:
         required: true
         type: string
       working_dir:
-        description: 'The directory of the Lambda function'
+        description: 'The directory of the Lambda function (e.g. services/<lambda>)'
         required: false
         default: '.'
         type: string
@@ -50,44 +50,48 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Debug AWS credentials configuration
-        run: |
-          aws sts get-caller-identity
+        run: aws sts get-caller-identity
 
-      - name: Check for modified policy JSON files
+      - name: Check for modified policy JSON & TF files
         id: check-modified-files
         shell: bash
         env:
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          # 1) Detect changed policy JSON files
-          modified_files=$(git diff --name-only HEAD~1 HEAD \
+          # 1) JSON diffs
+          modified_json_paths=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/[^/]*\.json$" || true)
-          if [ -n "$modified_files" ]; then
-            echo "[INFO] Modified policy JSON files: $modified_files"
+          if [[ -n "$modified_json_paths" ]]; then
+            echo "[INFO] Modified policy JSON files: $modified_json_paths"
             echo "modified=true" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No modified policy JSON files found."
             echo "modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # 2) Detect any Terraform (.tf) changes
-          tf_changed=$(git diff --name-only HEAD~1 HEAD \
+          # 2) TF diffs → capture only basenames
+          tf_paths=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/.*\.tf$" || true)
-          if [ -n "$tf_changed" ]; then
-            echo "[INFO] Terraform files changed: $tf_changed"
+          if [[ -n "$tf_paths" ]]; then
+            echo "[INFO] Terraform files changed: $tf_paths"
             echo "tf-modified=true" >> "$GITHUB_OUTPUT"
-            echo "tf-files=$(printf '%s ' $tf_changed)" >> "$GITHUB_OUTPUT"
+            tf_basenames=()
+            for p in $tf_paths; do
+              tf_basenames+=( "$(basename "$p")" )
+            done
+            # join with spaces
+            echo "tf-files=$(printf '%s ' "${tf_basenames[@]}")" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No Terraform changes detected."
             echo "tf-modified=false" >> "$GITHUB_OUTPUT"
             echo "tf-files=" >> "$GITHUB_OUTPUT"
           fi
 
-          # 3) Detect changed default-policy JSON files
-          modified_default_files=$(git diff --name-only HEAD~1 HEAD \
+          # 3) Default-policy JSON diffs
+          modified_default_paths=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/default-policy/.*\.json$" || true)
-          if [ -n "$modified_default_files" ]; then
-            echo "[INFO] Modified default-policy JSON files: $modified_default_files"
+          if [[ -n "$modified_default_paths" ]]; then
+            echo "[INFO] Modified default-policy JSON files: $modified_default_paths"
             echo "default-modified=true" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No modified default-policy JSON files found."
@@ -101,33 +105,24 @@ jobs:
           PROJECT_NAME: ${{ inputs.project_name }}
           AWS_ACCOUNT_ID: ${{ inputs.aws_account_id }}
           AWS_REGION: ${{ vars.AWS_REGION }}
-          ORG_AWS_REGION: ${{ vars.AWS_REGION }}
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
-          WORKING_DIR: ${{ inputs.working_dir }}
+          ORG_AWS_REGION: ${{ vars.AWS_REGION }}
         run: |
-          # Get modified default-policy JSON files
           modified_default_files=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/default-policy/.*\.json$")
-
           for file in $modified_default_files; do
-            # Skip TrustPolicy.json and ECRCrossAccountAccessPolicy.json
             base=$(basename "$file")
             if [[ "$base" == "TrustPolicy.json" || "$base" == "ECRCrossAccountAccessPolicy.json" ]]; then
               continue
             fi
-
             policy_name="$PROJECT_NAME-${base%.json}"
             echo "[INFO] Updating default policy $policy_name from $base"
-
-            # Substitute placeholders
             sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
                     s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
                     s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
                     s/\${ORG_AWS_ACCOUNT_ID}/$ORG_AWS_ACCOUNT_ID/g; \
                     s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
                     s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$base"
-
-            # Delete non-default policy versions
             versions=$(aws iam list-policy-versions \
               --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
               --query 'Versions[?IsDefaultVersion==`false`].VersionId' \
@@ -138,8 +133,6 @@ jobs:
                 --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
                 --version-id "$v"
             done
-
-            # Create new default version
             echo "[INFO] Creating new default version of $policy_name"
             aws iam create-policy-version \
               --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
@@ -154,49 +147,54 @@ jobs:
           PROJECT_NAME: ${{ inputs.project_name }}
           AWS_ACCOUNT_ID: ${{ inputs.aws_account_id }}
           AWS_REGION: ${{ vars.AWS_REGION }}
-          ORG_AWS_REGION: ${{ vars.AWS_REGION }}
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
-          WORKING_DIR: ${{ inputs.working_dir }}
+          ORG_AWS_REGION: ${{ vars.AWS_REGION }}
         run: |
-          # Generate a unique name for this temporary policy
+          # 1) Generate unique policy name
           timestamp=$(date -u +"%Y%m%d%H%M%S" -d '-6 hours')
           uuid=$(uuidgen | cut -c1-8)
           policy_name="temporary-${timestamp}-${uuid}"
           policy_file="${policy_name}.json"
 
-          # Decide which JSON files to include
+          # 2) Determine which JSONs to bundle
           if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
-            # Use only the JSON files that actually changed
-            files=($(git diff --name-only HEAD~1 HEAD \
-              | grep "^$WORKING_DIR/tf/[^/]*\.json$"))
+            echo "[INFO] Bundling only changed JSON policies"
+            mapfile -t json_paths < <(git diff --name-only HEAD~1 HEAD \
+              | grep "^$WORKING_DIR/tf/[^/]*\.json$")
+            files=()
+            for p in "${json_paths[@]}"; do
+              files+=( "$(basename "$p")" )
+            done
           else
-            # Scan changed TF files for templatefile("...json") references
             echo "[INFO] Scanning changed TF for JSON references"
             read -r -a tf_list <<< "${{ steps.check-modified-files.outputs.tf-files }}"
             refs=()
             for tf in "${tf_list[@]}"; do
-              grep -hoE 'templatefile\("([^"]+\.json)"' \
-                "$WORKING_DIR/tf/$tf" \
+              grep -hoE 'templatefile\("([^"]+\.json)"\)' "$tf" \
                 | sed -E 's/templatefile\("([^"]+)"\)/\1/' \
                 | while read -r f; do refs+=("$f"); done
             done
             files=($(printf "%s\n" "${refs[@]}" | sort -u))
           fi
 
-          # Build the combined temporary policy document
-          echo '{ "Version": "2012-10-17", "Statement": [' > "$policy_file"
-          first=true
-          for file in "${files[@]}"; do
-            if [ "$first" = true ]; then
-              first=false
-            else
-              echo "," >> "$policy_file"
-            fi
-            jq -c '.Statement[]' "$file" >> "$policy_file"
-          done
-          echo ']}' >> "$policy_file"
+          echo "[INFO] Files to attach: ${files[*]}"
 
-          # Substitute placeholders
+          # 3) Build the temporary policy doc
+          {
+            echo '{ "Version": "2012-10-17", "Statement": ['
+            first=true
+            for f in "${files[@]}"; do
+              if $first; then
+                first=false
+              else
+                echo ","
+              fi
+              jq -c '.Statement[]' "$f"
+            done
+            echo "]}"
+          } > "$policy_file"
+
+          # 4) Substitute placeholders
           sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
                   s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
                   s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
@@ -204,7 +202,7 @@ jobs:
                   s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
                   s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$policy_file"
 
-          # Create and attach the IAM policy
+          # 5) Create & attach
           aws iam create-policy \
             --policy-name "$policy_name" \
             --policy-document file://"$policy_file"

--- a/.github/workflows/check-new-policy-lambda-monorepo.yaml
+++ b/.github/workflows/check-new-policy-lambda-monorepo.yaml
@@ -60,23 +60,30 @@ jobs:
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
           # 1) Detect changed policy JSON files
-          modified_files=$(git diff --name-only HEAD~1 HEAD \
+          modified_json_paths=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/[^/]*\.json$" || true)
-          if [ -n "$modified_files" ]; then
-            echo "[INFO] Modified policy JSON files: $modified_files"
+          if [[ -n "$modified_json_paths" ]]; then
+            echo "[INFO] Modified policy JSON files: $modified_json_paths"
             echo "modified=true" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No modified policy JSON files found."
             echo "modified=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # 2) Detect any Terraform (.tf) changes
-          tf_changed=$(git diff --name-only HEAD~1 HEAD \
+          # 2) Detect any Terraform (.tf) changes, emit only basenames
+          tf_paths=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/.*\.tf$" || true)
-          if [ -n "$tf_changed" ]; then
-            echo "[INFO] Terraform files changed: $tf_changed"
+          if [[ -n "$tf_paths" ]]; then
+            echo "[INFO] Terraform files changed: $tf_paths"
             echo "tf-modified=true" >> "$GITHUB_OUTPUT"
-            echo "tf-files=$(printf '%s ' $tf_changed)" >> "$GITHUB_OUTPUT"
+
+            # strip prefix, keep only basename
+            basenames=()
+            for path in $tf_paths; do
+              basenames+=( "$(basename "$path")" )
+            done
+            tf_files=$(printf "%s " "${basenames[@]}")
+            echo "tf-files=$tf_files" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No Terraform changes detected."
             echo "tf-modified=false" >> "$GITHUB_OUTPUT"
@@ -84,10 +91,10 @@ jobs:
           fi
 
           # 3) Detect changed default-policy JSON files
-          modified_default_files=$(git diff --name-only HEAD~1 HEAD \
+          modified_default_paths=$(git diff --name-only HEAD~1 HEAD \
             | grep "^$WORKING_DIR/tf/default-policy/.*\.json$" || true)
-          if [ -n "$modified_default_files" ]; then
-            echo "[INFO] Modified default-policy JSON files: $modified_default_files"
+          if [[ -n "$modified_default_paths" ]]; then
+            echo "[INFO] Modified default-policy JSON files: $modified_default_paths"
             echo "default-modified=true" >> "$GITHUB_OUTPUT"
           else
             echo "[INFO] No modified default-policy JSON files found."
@@ -110,8 +117,8 @@ jobs:
             | grep "^$WORKING_DIR/tf/default-policy/.*\.json$")
 
           for file in $modified_default_files; do
-            # Skip TrustPolicy.json and ECRCrossAccountAccessPolicy.json
             base=$(basename "$file")
+            # Skip TrustPolicy.json and ECRCrossAccountAccessPolicy.json
             if [[ "$base" == "TrustPolicy.json" || "$base" == "ECRCrossAccountAccessPolicy.json" ]]; then
               continue
             fi
@@ -127,7 +134,7 @@ jobs:
                     s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
                     s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$base"
 
-            # Delete non-default policy versions
+            # Delete any old non-default versions
             versions=$(aws iam list-policy-versions \
               --policy-arn "arn:aws:iam::$AWS_ACCOUNT_ID:policy/$policy_name" \
               --query 'Versions[?IsDefaultVersion==`false`].VersionId' \
@@ -158,24 +165,28 @@ jobs:
           ORG_AWS_ACCOUNT_ID: ${{ vars.ORG_AWS_ACCOUNT_ID }}
           WORKING_DIR: ${{ inputs.working_dir }}
         run: |
-          # Generate a unique name for this temporary policy
+          # 1) Generate unique temporary policy name
           timestamp=$(date -u +"%Y%m%d%H%M%S" -d '-6 hours')
           uuid=$(uuidgen | cut -c1-8)
           policy_name="temporary-${timestamp}-${uuid}"
           policy_file="${policy_name}.json"
 
-          # Decide which JSON files to include
+          # 2) Decide which JSON(s) to bundle
           if [[ "${{ steps.check-modified-files.outputs.modified }}" == "true" ]]; then
-            # Use only the JSON files that actually changed
-            files=($(git diff --name-only HEAD~1 HEAD \
-              | grep "^$WORKING_DIR/tf/[^/]*\.json$"))
+            echo "[INFO] Bundling only changed JSON policies"
+            mapfile -t paths < <(git diff --name-only HEAD~1 HEAD \
+              | grep "^$WORKING_DIR/tf/[^/]*\.json$")
+            files=()
+            for p in "${paths[@]}"; do
+              files+=( "$(basename "$p")" )
+            done
+
           else
-            # Scan changed TF files for templatefile("...json") references
-            echo "[INFO] Scanning changed TF for JSON references"
+            echo "[INFO] No JSON diff; scanning TF for JSON references"
             read -r -a tf_list <<< "${{ steps.check-modified-files.outputs.tf-files }}"
             refs=()
             for tf in "${tf_list[@]}"; do
-              grep -hoE 'templatefile\("([^"]+\.json)"' \
+              grep -hoE 'templatefile\("([^"]+\.json)"\)' \
                 "$WORKING_DIR/tf/$tf" \
                 | sed -E 's/templatefile\("([^"]+)"\)/\1/' \
                 | while read -r f; do refs+=("$f"); done
@@ -183,20 +194,22 @@ jobs:
             files=($(printf "%s\n" "${refs[@]}" | sort -u))
           fi
 
-          # Build the combined temporary policy document
-          echo '{ "Version": "2012-10-17", "Statement": [' > "$policy_file"
+          echo "[INFO] Files to attach: ${files[*]}"
+
+          # 3) Build combined temporary policy document
+          echo '{ "Version":"2012-10-17", "Statement":[' > "$policy_file"
           first=true
-          for file in "${files[@]}"; do
-            if [ "$first" = true ]; then
+          for f in "${files[@]}"; do
+            if [[ "$first" == true ]]; then
               first=false
             else
               echo "," >> "$policy_file"
             fi
-            jq -c '.Statement[]' "$file" >> "$policy_file"
+            jq -c '.Statement[]' "$f" >> "$policy_file"
           done
-          echo ']}' >> "$policy_file"
+          echo "]}" >> "$policy_file"
 
-          # Substitute placeholders
+          # 4) Substitute placeholders
           sed -i "s/\${AWS_REGION}/$AWS_REGION/g; \
                   s/\${AWS_ACCOUNT_ID}/$AWS_ACCOUNT_ID/g; \
                   s/\${USER_NAME}/$GITHUB_REPOSITORY_OWNER/g; \
@@ -204,7 +217,7 @@ jobs:
                   s/\${ORG_AWS_REGION}/$ORG_AWS_REGION/g; \
                   s/\${PROJECT_NAME}/$PROJECT_NAME/g" "$policy_file"
 
-          # Create and attach the IAM policy
+          # 5) Create and attach the IAM policy
           aws iam create-policy \
             --policy-name "$policy_name" \
             --policy-document file://"$policy_file"


### PR DESCRIPTION
This pull request refactors and enhances the `.github/workflows/check-new-policy-lambda-monorepo.yaml` workflow to improve detection and handling of modified policy files and Terraform files in the Lambda monorepo. The changes make the workflow more robust, flexible, and maintainable by expanding file detection, optimizing policy updates, and streamlining the creation of temporary policies.

**File detection and workflow input improvements:**

* Expanded the detection logic to check for changes in both policy JSON files and Terraform (`.tf`) files, including extracting referenced JSON files from modified Terraform files. This allows the workflow to respond to a broader set of changes.
* Clarified the `working_dir` input description to specify the expected format (e.g., `services/<lambda>`), improving usability for workflow users.

**Policy update and creation enhancements:**

* Refactored the "Update default policy" step to streamline the update process, skip specific files, and use more concise variable naming and logic. The step now efficiently replaces placeholders and deletes old policy versions before creating new ones.
* Reworked the "Create and attach temporary policy" step to bundle only the relevant JSON files (either directly modified or referenced by changed Terraform files), construct the combined policy document more efficiently, and ensure proper placeholder substitution and attachment to the correct IAM role.

**Workflow maintenance and clarity:**

* Added minor formatting improvements and clarified some environment variable usage for consistency and maintainability. [[1]](diffhunk://#diff-c21a6712656460b0e361a205d446e49e93a958174212f83c871bd09fc275eef7R39) [[2]](diffhunk://#diff-c21a6712656460b0e361a205d446e49e93a958174212f83c871bd09fc275eef7L88-R203)