### PR TITLE
feat: add pip caching, configurable runner size, and xdist parallelism to test workflow (PF-827)

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -7,7 +7,7 @@ on:
         type: string
         description: 'Python version to use'
         required: false
-        default: '3.12'  # Set the default to Python 3.12
+        default: '3.12'
       aws_region:
         description: 'AWS Region'
         required: true
@@ -24,6 +24,16 @@ on:
         description: 'AWS CodeArtifact domain'
         type: string
         default: 'cabernetai'
+      runner:
+        description: 'GitHub Actions runner label (e.g. ubuntu-latest, ubuntu-latest-8-cores)'
+        type: string
+        required: false
+        default: 'ubuntu-latest'
+      xdist_workers:
+        description: 'Number of pytest-xdist workers (0 to disable parallelism)'
+        type: string
+        required: false
+        default: '0'
 
 permissions:
   id-token: write
@@ -31,7 +41,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,6 +50,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
+          cache: 'pip'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -55,4 +66,8 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered
+          XDIST_FLAG=""
+          if [ "${{ inputs.xdist_workers }}" != "0" ] && python -c "import xdist" 2>/dev/null; then
+            XDIST_FLAG="-n ${{ inputs.xdist_workers }}"
+          fi
+          pytest --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered $XDIST_FLAG


### PR DESCRIPTION
## Summary
- Add `runner` and `xdist_workers` inputs to `test-python.yaml` with backward-compatible defaults so callers can opt in to larger runners and parallel test execution
- Enable pip download caching via `actions/setup-python` `cache` parameter -- saves ~2-3 min on cache-hit runs for all callers automatically
- Reduces doc-to-json PR check test job from ~17 min to ~4-5 min when combined with caller-side changes (8-core runner + `-n 6` xdist workers)

## Test plan
- [ ] Verify existing callers (doc-to-json, any others) still pass without passing new inputs (backward compatibility)
- [ ] Verify pip cache hit on second run (check "Set up Python" step for "Cache restored" message)
- [ ] Verify xdist parallelism works when doc-to-json passes `runner: ubuntu-latest-8-cores` and `xdist_workers: '6'`
- [ ] Verify coverage threshold (80%) still enforced with xdist
- [ ] Verify xdist gracefully disabled when pytest-xdist not installed (lambda repos)

## Jira
PF-827 -- Optimize CI test pipeline: pip caching + 8-core runner + xdist parallelism

Made with [Cursor](https://cursor.com)