### PR TITLE
feat: add requirements_files + coverage_min inputs to test-python.yaml (PF-920)

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -34,6 +34,16 @@ on:
         type: string
         required: false
         default: '0'
+      requirements_files:
+        description: 'Newline-delimited list of pip requirements files to install'
+        type: string
+        required: false
+        default: "requirements.txt\ntests/requirements_test.txt"
+      coverage_min:
+        description: 'Minimum coverage % (empty = no enforcement, e.g. "81")'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   id-token: write
@@ -61,8 +71,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r tests/requirements_test.txt
+          echo "${{ inputs.requirements_files }}" | while IFS= read -r file; do
+            [ -n "$file" ] && pip install -r "$file"
+          done
 
       - name: Run tests with coverage
         run: |
@@ -70,4 +81,8 @@ jobs:
           if [ "${{ inputs.xdist_workers }}" != "0" ] && python -c "import xdist" 2>/dev/null; then
             XDIST_FLAG="-n ${{ inputs.xdist_workers }}"
           fi
-          pytest --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered $XDIST_FLAG
+          COV_MIN_FLAG=""
+          if [ -n "${{ inputs.coverage_min }}" ]; then
+            COV_MIN_FLAG="--cov-fail-under=${{ inputs.coverage_min }}"
+          fi
+          pytest --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered $XDIST_FLAG $COV_MIN_FLAG

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -69,20 +69,29 @@ jobs:
           aws-region: ${{ inputs.aws_region }}
 
       - name: Install dependencies
+        env:
+          REQUIREMENTS_FILES: ${{ inputs.requirements_files }}
         run: |
           python -m pip install --upgrade pip
-          echo "${{ inputs.requirements_files }}" | while IFS= read -r file; do
+          echo "$REQUIREMENTS_FILES" | while IFS= read -r file; do
             [ -n "$file" ] && pip install -r "$file"
           done
 
       - name: Run tests with coverage
+        env:
+          XDIST_WORKERS: ${{ inputs.xdist_workers }}
+          COVERAGE_MIN: ${{ inputs.coverage_min }}
         run: |
           XDIST_FLAG=""
-          if [ "${{ inputs.xdist_workers }}" != "0" ] && python -c "import xdist" 2>/dev/null; then
-            XDIST_FLAG="-n ${{ inputs.xdist_workers }}"
+          if [ "$XDIST_WORKERS" != "0" ] && python -c "import xdist" 2>/dev/null; then
+            XDIST_FLAG="-n $XDIST_WORKERS"
           fi
           COV_MIN_FLAG=""
-          if [ -n "${{ inputs.coverage_min }}" ]; then
-            COV_MIN_FLAG="--cov-fail-under=${{ inputs.coverage_min }}"
+          if [ -n "$COVERAGE_MIN" ]; then
+            if ! echo "$COVERAGE_MIN" | grep -qE '^[0-9]+$'; then
+              echo "::error::coverage_min must be a numeric value, got: $COVERAGE_MIN"
+              exit 1
+            fi
+            COV_MIN_FLAG="--cov-fail-under=$COVERAGE_MIN"
           fi
           pytest --cov --cov-config=.coveragerc --cov-report=term-missing:skip-covered $XDIST_FLAG $COV_MIN_FLAG


### PR DESCRIPTION
## Summary
- Adds two backwards-compatible inputs to the shared `test-python.yaml` reusable workflow:
  - **`requirements_files`**: newline-delimited list of pip requirements files (default preserves current `requirements.txt` + `tests/requirements_test.txt`)
  - **`coverage_min`**: optional minimum coverage percentage for `--cov-fail-under` (default empty = no enforcement)
- Parameterizes the install step to loop over `requirements_files` and the pytest step to optionally enforce a coverage floor

## Why
Unblocks PF-916 (layered requirements in doc-to-json). The PF-916 branch had to inline the test job because this reusable workflow hardcoded `requirements.txt`. With these inputs, the caller can pass `requirements_files: 'requirements-dev.txt'` and `coverage_min: '81'` to restore the shared-infra pattern.

## Backwards compatibility
- Only 2 callers exist (both in `ib-agent/doc-to-json`), and both currently inline the test job (don't call this workflow at all)
- The old caller pattern passed no value for the new inputs, so defaults preserve identical behavior
- No other repo in `ib-agent` references `test-python.yaml`

## Test plan
- [x] Verified defaults match current hardcoded behavior (`requirements.txt` + `tests/requirements_test.txt`, no coverage gate)
- [x] Confirmed no other consumers in the org via `gh search code`
- [ ] Merge this PR, then restore caller pattern in doc-to-json PF-916 branch to confirm `call_test / test` reports green

## Jira
PF-920

Made with [Cursor](https://cursor.com)